### PR TITLE
Added new line to CLI tool 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,6 +178,10 @@ Otherwise, `shoot us an email`_.
 Changelog
 ---------
 
+**0.1.2**: 10-23-2016
+
+- Supporting ``api_key_id`` ``api_key_secret`` and ``base_url`` arguments for one-time use.
+
 **0.1.1**: 10-17-2016
 
 - Supporting ``--base-url`` argument.

--- a/README.rst
+++ b/README.rst
@@ -181,6 +181,7 @@ Changelog
 **0.1.2**: 10-23-2016
 
 - Supporting ``api_key_id`` ``api_key_secret`` and ``base_url`` arguments for one-time use.
+- Fixing documentation.
 
 **0.1.1**: 10-17-2016
 

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,9 @@ Usage
 
 Before you can export all your `Stormpath`_ data, you'll need to configure
 ``stormpath-export`` and give it your Stormpath API credentials. To do this,
-simply run:
+you have two options.
+
+1) To save your credentials locally, simply run:
 
 .. code-block:: console
 
@@ -86,8 +88,17 @@ This will prompt you for some basic information, then store your credentials
 in the local file ``~/.stormy``.
 
 NOTE: If you are using Stormpath Enterprise, please enter
-``https://enterprise.stormpath.io/v1`` when prompted for the Base URL.  This
+``https://enterprise.stormpath.io/v1`` when prompted for the Base URL. This
 instructs the export tool to talk to the Stormpath Enterprise environment.
+
+2) To specify your credentials for one-time use, simply run:
+
+.. code-block:: console
+
+    $ stormpath-export $STORMPATH_API_KEY_ID $STORMPATH_API_KEY_SECRET $BASE_URL
+
+NOTE: $BASE_URL is an optional argument. If you don't enter a Base URL, we will
+automatically try to authenticate against ``https://api.stormpath.com/v1``.
 
 Next, to initiate a backup job, you can run:
 
@@ -144,6 +155,7 @@ For full usage information, run ``stormpath-export -h``:
     Usage:
       stormpath-export configure
       stormpath-export [(<location> | -l <location> | --location <location>)]
+      stormpath-export [(<stormpath_api_key_id> <stormpath_api_key_secret>) [(<stormpath_base_url>)]]
       stormpath-export (-h | --help)
       stormpath-export --version
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
 
     # Basic package information:
     name = 'stormpath-export',
-    version = '0.1.1',
+    version = '0.1.2',
     scripts = ('stormpath-export', ),
 
     # Packaging options:

--- a/stormpath-export
+++ b/stormpath-export
@@ -7,8 +7,8 @@ Easily export your Stormpath (https://stormpath.com/) user data.
 
 Usage:
   stormpath-export configure
-  stormpath-export [(<location> | -l <location> | --location <location>) (-b <base_url> | --base-url <base_url>)]
-  stormpath-export [(-b <base_url> | --base-url <base_url>)]
+  stormpath-export [(<location> | -l <location> | --location <location>)]
+  stormpath-export [(<api_key_id> <api_key_secret>) [(<base_url>)]]
   stormpath-export (-h | --help)
   stormpath-export --version
 
@@ -32,7 +32,7 @@ from stormpath.error import Error
 
 ##### GLOBALS
 CONFIG_FILE = expanduser('~/.stormy')
-VERSION = 'stormpath-export 0.1.1'
+VERSION = 'stormpath-export 0.1.2'
 
 
 class StormpathExport(object):
@@ -40,14 +40,19 @@ class StormpathExport(object):
 
     EXPORTS = ['tenants', 'applications', 'directories', 'groups', 'organizations', 'accounts']
 
-    def __init__(self, base_url):
+    def __init__(self, stormpath_api_key_id=None, stormpath_api_key_secret=None, stormpath_base_url=None):
         """Initialize our Stormpath client, or die tryin' >:)"""
         if exists(CONFIG_FILE):
             credentials = loads(open(CONFIG_FILE, 'r').read())
             self.client = Client(api_key={
                 'id': credentials.get('stormpath_api_key_id'),
                 'secret': credentials.get('stormpath_api_key_secret'),
-            }, base_url=credentials.get('stormpath_base_url') or base_url or None)
+            }, base_url=credentials.get('stormpath_base_url') or None)
+        elif stormpath_api_key_id and stormpath_api_key_secret:
+            self.client = Client(api_key={
+                'id': stormpath_api_key_id,
+                'secret': stormpath_api_key_secret,
+            }, base_url=stormpath_base_url or None)
         else:
             print('No API credentials found! Please run stormpath-export configure to set them up.')
             exit(1)
@@ -546,7 +551,7 @@ class StormpathExport(object):
             getattr(self, 'export_' + export_type)()
 
 
-def configure(base_url=None):
+def configure():
     """
     Initializing stormpath-export.
 
@@ -600,10 +605,10 @@ def main():
     # Handle the configure as a special case -- this way we won't get invalid
     # API credential messages when we're trying to configure stormpath-export.
     if arguments['configure']:
-        configure(base_url=arguments['<base_url>'])
+        configure()
         return
 
-    exporter = StormpathExport(arguments['<base_url>'])
+    exporter = StormpathExport(arguments['<api_key_id>'],arguments['<api_key_secret>'],arguments['<base_url>'])
     exporter.export(arguments['<location>'])
 
 

--- a/stormpath-export
+++ b/stormpath-export
@@ -8,7 +8,7 @@ Easily export your Stormpath (https://stormpath.com/) user data.
 Usage:
   stormpath-export configure
   stormpath-export [(<location> | -l <location> | --location <location>)]
-  stormpath-export [(<api_key_id> <api_key_secret>) [(<base_url>)]]
+  stormpath-export [(<stormpath_api_key_id> <stormpath_api_key_secret>) [(<stormpath_base_url>)]]
   stormpath-export (-h | --help)
   stormpath-export --version
 
@@ -608,7 +608,7 @@ def main():
         configure()
         return
 
-    exporter = StormpathExport(arguments['<api_key_id>'],arguments['<api_key_secret>'],arguments['<base_url>'])
+    exporter = StormpathExport(arguments['<stormpath_api_key_id>'],arguments['<stormpath_api_key_secret>'],arguments['<stormpath_base_url>'])
     exporter.export(arguments['<location>'])
 
 


### PR DESCRIPTION
Added new line to this CLI tool: 

`stormpath-export [(<stormpath_api_key_id> <stormpath_api_key_secret>) [(<stormpath_base_url>)]]`

This lets users do a one-time export by specifying their credentials on the command line, instead of being forced to enter them and have them saved locally (in a .stormy file). 
